### PR TITLE
Broccoli 1.0 Support and Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
-  - "node"
+  - 4
+  - 6
+  - 8
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ function ZopfliFilter(inputTree, options) {
                          options.appendSuffix :
                          true);
 
+    // Default file encoding is raw to handle binary files
+    this.inputEncoding = options.inputEncoding || null;
+    this.outputEncoding = options.outputEncoding || null;
+
     if (this.keepUncompressed && !this.appendSuffix) {
         throw new Error('Cannot keep uncompressed files without appending suffix. Filenames would be the same.');
     }

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function ZopfliFilter(inputTree, options) {
         throw new Error('Cannot keep uncompressed files without appending suffix. Filenames would be the same.');
     }
 
-    Filter.apply(this, arguments);
+    Filter.call(this, inputTree, options);
 }
 
 ZopfliFilter.prototype.processFile = function(srcDir, destDir, relativePath) {
@@ -57,6 +57,10 @@ ZopfliFilter.prototype.processFile = function(srcDir, destDir, relativePath) {
 
     return Filter.prototype.processFile.apply(this, arguments);
 };
+
+ZopfliFilter.prototype.baseDir = function() {
+  return __dirname;
+}
 
 ZopfliFilter.prototype.processString = function(str) {
     return RSVP.denodeify(zopfli.gzip)(new Buffer(str), this.zopfliOptions);

--- a/package.json
+++ b/package.json
@@ -15,17 +15,17 @@
         "zopfli"
     ],
     "devDependencies": {
-        "broccoli": "^0.11.0",
+        "broccoli": "^1.1.0",
         "expect.js": "^0.3.1",
-        "mocha": "^1.18.2"
+        "mocha": "^3.2.0"
     },
     "scripts": {
         "test": "mocha tests/"
     },
     "dependencies": {
-        "broccoli-filter": "^0.1.6",
-        "broccoli-kitchen-sink-helpers": "^0.2.2",
-        "rsvp": "^3.0.6",
-        "node-zopfli": "~1.4.0"
+        "broccoli-filter": "^1.2.4",
+        "broccoli-kitchen-sink-helpers": "^0.3.1",
+        "rsvp": "^3.3.3",
+        "node-zopfli": "^2.0.2"
     }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,7 +12,7 @@ var csvContent = fs.readFileSync('tests/fixtures/sample-assets/test.csv');
 
 var builder;
 
-describe('broccoli-gzip', function(){
+describe('broccoli-zopfli', function(){
     afterEach(function() {
         if (builder) {
             builder.cleanup();
@@ -26,12 +26,13 @@ describe('broccoli-gzip', function(){
         });
 
         builder = new broccoli.Builder(tree);
-        return builder.build().then(function(build) {
-            var gzippedText = fs.readFileSync(build.directory + '/test.txt.gz');
+        return builder.build().then(function() {
+            var outputPath = builder.outputPath;
+            var gzippedText = fs.readFileSync(outputPath + '/test.txt.gz');
 
             return RSVP.hash({
-                dir: build.directory,
-                actualCsv: fs.readFileSync(build.directory + '/test.csv'),
+                dir: outputPath,
+                actualCsv: fs.readFileSync(outputPath + '/test.csv'),
                 actualText: RSVP.denodeify(zlib.gunzip)(gzippedText)
             });
         }).then(function(result) {
@@ -49,11 +50,12 @@ describe('broccoli-gzip', function(){
         });
 
         builder = new broccoli.Builder(tree);
-        return builder.build().then(function(build) {
-            var gzippedText = fs.readFileSync(build.directory + '/test.txt.gz');
+        return builder.build().then(function() {
+            var outputPath = builder.outputPath;
+            var gzippedText = fs.readFileSync(outputPath + '/test.txt.gz');
             return RSVP.hash({
-                dir: build.directory,
-                actualCsv: fs.readFileSync(build.directory + '/test.csv'),
+                dir: outputPath,
+                actualCsv: fs.readFileSync(outputPath + '/test.csv'),
                 actualText: RSVP.denodeify(zlib.gunzip)(gzippedText)
             });
         }).then(function(result) {
@@ -71,10 +73,11 @@ describe('broccoli-gzip', function(){
         });
 
         builder = new broccoli.Builder(tree);
-        return builder.build().then(function(build) {
-            var gzippedText = fs.readFileSync(build.directory + '/test.txt');
+        return builder.build().then(function() {
+            var outputPath = builder.outputPath;
+            var gzippedText = fs.readFileSync(outputPath + '/test.txt');
             return RSVP.hash({
-                dir: build.directory,
+                dir: outputPath,
                 actualText: RSVP.denodeify(zlib.gunzip)(gzippedText)
             });
         }).then(function(result) {


### PR DESCRIPTION
This ports the following changes from broccoli-gzip:

* Broccoli 1.0 Support
* Fix handling of binary files

Updates:

* Updated dependencies to match broccoli-gzip
* Updated node-zopfli to 2.0.2 to support Node.js 7
* Update Travis CI build matrix

Breaking changes:

* Requires broccoli 1.0
* Node 0.10 is no longer supported due to the upgrade to node-zopfli 2.0